### PR TITLE
Exclude `/files/` indexing on Google

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: Googlebot
+Disallow: /files/


### PR DESCRIPTION
Exclude `/files/` indexing on Google using robots.txt